### PR TITLE
[New Feature] Add data index clearing capability

### DIFF
--- a/elastic-container.sh
+++ b/elastic-container.sh
@@ -31,6 +31,7 @@ usage() {
     destroy   stops and removes the containers, the network and volumes created
     restart   simply restarts all the stack containers
     status    check the status of the stack containers
+    clear     clear all documents in logs and metrics indexes
     help      print this message
   flags:
     -v        enable verbose output
@@ -87,11 +88,26 @@ get_host_ip() {
 }
 
 set_fleet_values() {
-  fingerprint=$(docker compose exec -w /usr/share/elasticsearch/config/certs/ca elasticsearch cat ca.crt | openssl x509 -noout -fingerprint -sha256 | cut -d "=" -f 2 | tr -d :)
+  fingerprint=$(docker-compose exec -w /usr/share/elasticsearch/config/certs/ca elasticsearch cat ca.crt | openssl x509 -noout -fingerprint -sha256 | cut -d "=" -f 2 | tr -d :)
   printf '{"fleet_server_hosts": ["%s"]}' "https://${ipvar}:${FLEET_PORT}" | curl -k --silent --user "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}" -XPUT "${HEADERS[@]}" "${LOCAL_KBN_URL}/api/fleet/settings" -d @- | jq 
   printf '{"hosts": ["%s"]}' "https://${ipvar}:9200" | curl -k --silent --user "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}" -XPUT "${HEADERS[@]}" "${LOCAL_KBN_URL}/api/fleet/outputs/fleet-default-output" -d @- | jq 
   printf '{"ca_trusted_fingerprint": "%s"}' "${fingerprint}" | curl -k --silent --user "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}" -XPUT "${HEADERS[@]}" "${LOCAL_KBN_URL}/api/fleet/outputs/fleet-default-output" -d @- | jq 
   printf '{"config_yaml": "%s"}' "ssl.verification_mode: certificate" | curl -k --silent --user "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}" -XPUT "${HEADERS[@]}" "${LOCAL_KBN_URL}/api/fleet/outputs/fleet-default-output" -d @- | jq 
+}
+
+clear_documents() {
+  if (( $(  curl -k --silent "${HEADERS[@]}" --user "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}" -X DELETE "https://${ipvar}:9200/_data_stream/logs-*" | grep -c "true" ) > 0 )) ; then
+    printf "Successfully cleared logs data stream"
+  else 
+    printf "Failed to clear logs data stream"
+  fi
+  echo 
+  if (( $(  curl -k --silent "${HEADERS[@]}" --user "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}" -X DELETE "https://${ipvar}:9200/_data_stream/metrics-*" | grep -c "true" ) > 0 )) ; then
+    printf "Successfully cleared metrics data stream"
+  else 
+    printf "Failed to clear metrics data stream"
+  fi
+  echo
 }
 
 # Logic to enable the verbose output if needed
@@ -180,6 +196,10 @@ case "${ACTION}" in
 
 "status")
   docker-compose ps | grep -v setup
+  ;;
+
+"clear")
+  clear_documents 
   ;;
 
 "help")

--- a/elastic-container.sh
+++ b/elastic-container.sh
@@ -88,7 +88,7 @@ get_host_ip() {
 }
 
 set_fleet_values() {
-  fingerprint=$(docker-compose exec -w /usr/share/elasticsearch/config/certs/ca elasticsearch cat ca.crt | openssl x509 -noout -fingerprint -sha256 | cut -d "=" -f 2 | tr -d :)
+  fingerprint=$(docker compose exec -w /usr/share/elasticsearch/config/certs/ca elasticsearch cat ca.crt | openssl x509 -noout -fingerprint -sha256 | cut -d "=" -f 2 | tr -d :)
   printf '{"fleet_server_hosts": ["%s"]}' "https://${ipvar}:${FLEET_PORT}" | curl -k --silent --user "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}" -XPUT "${HEADERS[@]}" "${LOCAL_KBN_URL}/api/fleet/settings" -d @- | jq 
   printf '{"hosts": ["%s"]}' "https://${ipvar}:9200" | curl -k --silent --user "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}" -XPUT "${HEADERS[@]}" "${LOCAL_KBN_URL}/api/fleet/outputs/fleet-default-output" -d @- | jq 
   printf '{"ca_trusted_fingerprint": "%s"}' "${fingerprint}" | curl -k --silent --user "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}" -XPUT "${HEADERS[@]}" "${LOCAL_KBN_URL}/api/fleet/outputs/fleet-default-output" -d @- | jq 


### PR DESCRIPTION
This PR adds the ability for a user to clear or wipe the default data streams (logs & metrics) via the elastic-container.sh cli using the new "clear" option. This option comes in handy when you want your stack to remain persistent but want to start fresh, in terms of data, at a particular time. 