### PR TITLE
Update docker-compose to "docker compose"

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Stand up a 100% containerized Elastic stack, TLS secured, with Elasticsearch, Ki
 
 ### Prerequisites: 
 
-- [docker](https://docs.docker.com/get-docker/), [docker-compose](https://docs.docker.com/compose/), [jq](https://stedolan.github.io/jq/download/), [curl](https://curl.se/download.html), and [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
+- [Docker suite](https://docs.docker.com/get-docker/), [jq](https://stedolan.github.io/jq/download/), [curl](https://curl.se/download.html), and [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
 
 You can use the links above, the Linux package install commands below, or [Homebrew](https://brew.sh/) if your'e on MacOS
 
@@ -31,14 +31,17 @@ MacOS:
 brew install jq git curl
 brew install --cask docker
 ```
-Debian or Ubuntu:
+Ubuntu:
+[Docker installation instructions](https://docs.docker.com/engine/install/ubuntu/)
 ```
-apt install docker jq git curl docker-compose
+apt-get install jq git curl
 ```
-Fedora or CentOS:
+Fedora:
+[Docker installation instructions](https://docs.docker.com/engine/install/fedora/)
 ```
-dnf install docker jq git curl docker-compose
+dnf install jq git curl
 ```
+[Docker installation instructions for other distros](https://docs.docker.com/engine/install/)
 
 ## Usage
 

--- a/elastic-container.sh
+++ b/elastic-container.sh
@@ -136,7 +136,7 @@ case "${ACTION}" in
 
   echo "Starting Elastic Stack network and containers"
 
-  docker-compose up -d --no-deps
+  docker compose up -d --no-deps
 
   configure_kbn 1>&2 2>&3
 
@@ -160,26 +160,26 @@ case "${ACTION}" in
 "stop")
   echo "Stopping running containers."
   
-  docker-compose stop
+  docker compose stop
   ;;
 
 "destroy")
   echo "#####"
   echo "Stopping and removing the containers, network, and volumes created."
   echo "#####"
-  docker-compose down -v
+  docker compose down -v
   ;;
 
 "restart")
   echo "#####"
   echo "Restarting all Elastic Stack components."
   echo "#####"
-  docker-compose restart elasticsearch kibana fleet-server  2>&3
-  docker-compose ps | grep -v setup
+  docker compose restart elasticsearch kibana fleet-server  2>&3
+  docker compose ps | grep -v setup
   ;;
 
 "status")
-  docker-compose ps | grep -v setup
+  docker compose ps | grep -v setup
   ;;
 
 "help")


### PR DESCRIPTION
Closes #9 

Background:
`docker-compose` is being deprecated in favor of `docker compose` and using the `docker-compose-plugin`.

This PR removes `docker-compose` entirely and changes to the new approach of `docker compose` so that this will work across macOS and Linux.

I tested with macOS, Ubuntu, and CentOS.