### PR TITLE
Adds fallback support for docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}
     container_name: elasticsearch-security-setup
     volumes:
-      - certs:/usr/share/elasticsearch/config/certs
+      - certs:/usr/share/elasticsearch/config/certs:z
     user: "0"
     command: >
       bash -c '
@@ -117,9 +117,9 @@ services:
     image: docker.elastic.co/kibana/kibana:${STACK_VERSION}
     container_name: kibana
     volumes:
-      - certs:/usr/share/kibana/config/certs
+      - certs:/usr/share/kibana/config/certs:z
       - kibanadata:/usr/share/kibana/data
-      - ./kibana.yml:/usr/share/kibana/config/kibana.yml
+      - ./kibana.yml:/usr/share/kibana/config/kibana.yml:Z
     ports:
       - ${KIBANA_PORT}:5601
     environment:
@@ -152,7 +152,7 @@ services:
       image: docker.elastic.co/beats/elastic-agent:${STACK_VERSION}
       container_name: fleet-server
       volumes:
-        - certs:/certs
+        - certs:/certs:z
       ports:
         - ${FLEET_PORT}:8220
       restart: always

--- a/elastic-container.sh
+++ b/elastic-container.sh
@@ -212,7 +212,7 @@ case "${ACTION}" in
 
   echo "Starting Elastic Stack network and containers"
 
-  ${COMPOSE} up -d --no-deps 2>&3
+  ${COMPOSE} up -d --no-deps 
 
   configure_kbn 1>&2 2>&3
 
@@ -222,7 +222,7 @@ case "${ACTION}" in
   sleep 40
 
   echo "Populating Fleet Settings"
-  set_fleet_values 1>&2 2>&3
+  set_fleet_values > /dev/null 2>&1
   echo
 
   echo "READY SET GO!"
@@ -236,7 +236,7 @@ case "${ACTION}" in
 "stop")
   echo "Stopping running containers."
 
-  ${COMPOSE} stop 2>&3
+  ${COMPOSE} stop 
   ;;
 
 "destroy")
@@ -250,8 +250,7 @@ case "${ACTION}" in
   echo "#####"
   echo "Restarting all Elastic Stack components."
   echo "#####"
-  ${COMPOSE} restart elasticsearch kibana fleet-server 2>&3
-  ${COMPOSE} ps | grep -v setup
+  ${COMPOSE} restart elasticsearch kibana fleet-server 
   ;;
 
 "status")

--- a/elastic-container.sh
+++ b/elastic-container.sh
@@ -8,19 +8,11 @@ declare LinuxDR
 declare WindowsDR
 declare MacOSDR
 
+declare COMPOSE
+
 # Ignore following warning
 # shellcheck disable=SC1091
 . .env
-
-declare COMPOSE
-if docker compose 2>/dev/null; then
-  COMPOSE="docker compose"
-elif command -v docker-compose >/dev/null; then
-  COMPOSE="docker-compose"
-else
-  echo "elastic-container requires docker compose!"
-  exit 2
-fi
 
 HEADERS=(
   -H "kbn-version: ${STACK_VERSION}"
@@ -195,6 +187,15 @@ else
   exec 3<>/dev/null
 fi
 
+if docker compose >/dev/null; then
+  COMPOSE="docker compose"
+elif command -v docker-compose >/dev/null; then
+  COMPOSE="docker-compose"
+else
+  echo "elastic-container requires docker compose!"
+  exit 2
+fi
+
 case "${ACTION}" in
 
 "stage")
@@ -211,7 +212,7 @@ case "${ACTION}" in
 
   echo "Starting Elastic Stack network and containers"
 
-  ${COMPOSE} up -d --no-deps
+  ${COMPOSE} up -d --no-deps 2>&3
 
   configure_kbn 1>&2 2>&3
 
@@ -221,7 +222,7 @@ case "${ACTION}" in
   sleep 40
 
   echo "Populating Fleet Settings"
-  set_fleet_values >/dev/null 2>&1
+  set_fleet_values 1>&2 2>&3
   echo
 
   echo "READY SET GO!"
@@ -235,7 +236,7 @@ case "${ACTION}" in
 "stop")
   echo "Stopping running containers."
 
-  ${COMPOSE} stop
+  ${COMPOSE} stop 2>&3
   ;;
 
 "destroy")

--- a/elastic-container.sh
+++ b/elastic-container.sh
@@ -3,7 +3,24 @@ set -o pipefail
 
 ipvar="0.0.0.0"
 
+# These should be set in the .env file
+declare LinuxDR
+declare WindowsDR
+declare MacOSDR
+
+# Ignore following warning
+# shellcheck disable=SC1091
 . .env
+
+declare COMPOSE
+if docker compose 2>/dev/null; then
+  COMPOSE="docker compose"
+elif command -v docker-compose >/dev/null; then
+  COMPOSE="docker-compose"
+else
+  echo "elastic-container requires docker compose!"
+  exit 2
+fi
 
 HEADERS=(
   -H "kbn-version: ${STACK_VERSION}"
@@ -12,11 +29,12 @@ HEADERS=(
 )
 
 passphrase_reset() {
-  if grep -Fq "changeme" .env; 
-  then echo "Sorry, looks like you haven't updated the passphrase from the default";
-  echo "Please update the changeme passphrases in the .env file.";
-  exit 1;
-  else echo "Passphrase has been reset. Proceeding.";
+  if grep -Fq "changeme" .env; then
+    echo "Sorry, looks like you haven't updated the passphrase from the default"
+    echo "Please update the changeme passphrases in the .env file."
+    exit 1
+  else
+    echo "Passphrase has been reset. Proceeding."
   fi
 }
 
@@ -26,8 +44,8 @@ usage() {
   usage: ./elastic-container.sh [-v] (stage|start|stop|restart|status|help)
   actions:
     stage     downloads all necessary images to local storage
-    start     creates a container network and starts containers 
-    stop      stops running containers without removing them 
+    start     creates a container network and starts containers
+    stop      stops running containers without removing them
     destroy   stops and removes the containers, the network, and volumes created
     restart   restarts all the stack containers
     status    check the status of the stack containers
@@ -74,13 +92,13 @@ configure_kbn() {
         if [ "${LinuxDR}" -eq 1 ]; then
 
           curl -k --silent "${HEADERS[@]}" --user "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}" -X POST "${LOCAL_KBN_URL}/api/detection_engine/rules/_bulk_action" -d'
-           {
+            {
               "query": "alert.attributes.tags: \"Linux\"",
               "action": "enable"
             }
             ' 1>&2
-            echo 
-            echo "Successfully enabled Linux detection rules"
+          echo
+          echo "Successfully enabled Linux detection rules"
         fi
         if [ "${WindowsDR}" -eq 1 ]; then
 
@@ -90,8 +108,8 @@ configure_kbn() {
               "action": "enable"
             }
             ' 1>&2
-            echo
-            echo "Successfully enabled Windows detection rules"
+          echo
+          echo "Successfully enabled Windows detection rules"
         fi
         if [ "${MacOSDR}" -eq 1 ]; then
 
@@ -101,8 +119,8 @@ configure_kbn() {
               "action": "enable"
             }
             ' 1>&2
-            echo
-            echo "Successfully enabled MacOS detection rules"
+          echo
+          echo "Successfully enabled MacOS detection rules"
         fi
       fi
       echo
@@ -112,40 +130,40 @@ configure_kbn() {
       echo "Kibana still loading. Trying again in 40 seconds"
     fi
 
-    sleep 40 
+    sleep 40
     i=$((i - 1))
   done
-  [ $i -eq 0 ] && echo "Exceeded MAXTRIES (${MAXTRIES}) to setup detection engine." && exit 1 
+  [ $i -eq 0 ] && echo "Exceeded MAXTRIES (${MAXTRIES}) to setup detection engine." && exit 1
   return 0
 }
 
 get_host_ip() {
   os=$(uname -s)
-  if [ ${os} == "Linux" ]; then
+  if [ "${os}" == "Linux" ]; then
     ipvar=$(hostname -I | awk '{ print $1}')
-  elif [ ${os} == "Darwin" ]; then
+  elif [ "${os}" == "Darwin" ]; then
     ipvar=$(ifconfig en0 | awk '$1 == "inet" {print $2}')
   fi
 }
 
 set_fleet_values() {
-  fingerprint=$(docker compose exec -w /usr/share/elasticsearch/config/certs/ca elasticsearch cat ca.crt | openssl x509 -noout -fingerprint -sha256 | cut -d "=" -f 2 | tr -d :)
-  printf '{"fleet_server_hosts": ["%s"]}' "https://${ipvar}:${FLEET_PORT}" | curl -k --silent --user "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}" -XPUT "${HEADERS[@]}" "${LOCAL_KBN_URL}/api/fleet/settings" -d @- | jq 
-  printf '{"hosts": ["%s"]}' "https://${ipvar}:9200" | curl -k --silent --user "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}" -XPUT "${HEADERS[@]}" "${LOCAL_KBN_URL}/api/fleet/outputs/fleet-default-output" -d @- | jq 
-  printf '{"ca_trusted_fingerprint": "%s"}' "${fingerprint}" | curl -k --silent --user "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}" -XPUT "${HEADERS[@]}" "${LOCAL_KBN_URL}/api/fleet/outputs/fleet-default-output" -d @- | jq 
-  printf '{"config_yaml": "%s"}' "ssl.verification_mode: certificate" | curl -k --silent --user "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}" -XPUT "${HEADERS[@]}" "${LOCAL_KBN_URL}/api/fleet/outputs/fleet-default-output" -d @- | jq 
+  fingerprint=$(${COMPOSE} exec -w /usr/share/elasticsearch/config/certs/ca elasticsearch cat ca.crt | openssl x509 -noout -fingerprint -sha256 | cut -d "=" -f 2 | tr -d :)
+  printf '{"fleet_server_hosts": ["%s"]}' "https://${ipvar}:${FLEET_PORT}" | curl -k --silent --user "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}" -XPUT "${HEADERS[@]}" "${LOCAL_KBN_URL}/api/fleet/settings" -d @- | jq
+  printf '{"hosts": ["%s"]}' "https://${ipvar}:9200" | curl -k --silent --user "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}" -XPUT "${HEADERS[@]}" "${LOCAL_KBN_URL}/api/fleet/outputs/fleet-default-output" -d @- | jq
+  printf '{"ca_trusted_fingerprint": "%s"}' "${fingerprint}" | curl -k --silent --user "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}" -XPUT "${HEADERS[@]}" "${LOCAL_KBN_URL}/api/fleet/outputs/fleet-default-output" -d @- | jq
+  printf '{"config_yaml": "%s"}' "ssl.verification_mode: certificate" | curl -k --silent --user "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}" -XPUT "${HEADERS[@]}" "${LOCAL_KBN_URL}/api/fleet/outputs/fleet-default-output" -d @- | jq
 }
 
 clear_documents() {
-  if (( $(  curl -k --silent "${HEADERS[@]}" --user "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}" -X DELETE "https://${ipvar}:9200/_data_stream/logs-*" | grep -c "true" ) > 0 )) ; then
+  if (($(curl -k --silent "${HEADERS[@]}" --user "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}" -X DELETE "https://${ipvar}:9200/_data_stream/logs-*" | grep -c "true") > 0)); then
     printf "Successfully cleared logs data stream"
-  else 
+  else
     printf "Failed to clear logs data stream"
   fi
-  echo 
-  if (( $(  curl -k --silent "${HEADERS[@]}" --user "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}" -X DELETE "https://${ipvar}:9200/_data_stream/metrics-*" | grep -c "true" ) > 0 )) ; then
+  echo
+  if (($(curl -k --silent "${HEADERS[@]}" --user "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}" -X DELETE "https://${ipvar}:9200/_data_stream/metrics-*" | grep -c "true") > 0)); then
     printf "Successfully cleared metrics data stream"
-  else 
+  else
     printf "Failed to clear metrics data stream"
   fi
   echo
@@ -193,7 +211,7 @@ case "${ACTION}" in
 
   echo "Starting Elastic Stack network and containers"
 
-  docker compose up -d --no-deps
+  ${COMPOSE} up -d --no-deps
 
   configure_kbn 1>&2 2>&3
 
@@ -203,7 +221,7 @@ case "${ACTION}" in
   sleep 40
 
   echo "Populating Fleet Settings"
-  set_fleet_values > /dev/null 2>&1
+  set_fleet_values >/dev/null 2>&1
   echo
 
   echo "READY SET GO!"
@@ -216,31 +234,31 @@ case "${ACTION}" in
 
 "stop")
   echo "Stopping running containers."
-  
-  docker compose stop
+
+  ${COMPOSE} stop
   ;;
 
 "destroy")
   echo "#####"
   echo "Stopping and removing the containers, network, and volumes created."
   echo "#####"
-  docker compose down -v
+  ${COMPOSE} down -v
   ;;
 
 "restart")
   echo "#####"
   echo "Restarting all Elastic Stack components."
   echo "#####"
-  docker compose restart elasticsearch kibana fleet-server  2>&3
-  docker compose ps | grep -v setup
+  ${COMPOSE} restart elasticsearch kibana fleet-server 2>&3
+  ${COMPOSE} ps | grep -v setup
   ;;
 
 "status")
-  docker compose ps | grep -v setup
+  ${COMPOSE} ps | grep -v setup
   ;;
 
 "clear")
-  clear_documents 
+  clear_documents
   ;;
 
 "help")


### PR DESCRIPTION
Open to discuss the changes and/or discard if it's not desired. 

- Still prefers `docker compose` command via the docker plugin (bundled with Docker Desktop)
- fallback to `docker-compose` allows for using podman or docker ce
- also adds selinux flags for shared volumes, should be ignored where not supported
- Formats using shell-format and cleans up shellcheck problems