### PR TITLE
feat: add required applications check to start command flow

### DIFF
--- a/elastic-container.sh
+++ b/elastic-container.sh
@@ -30,6 +30,19 @@ passphrase_reset() {
   fi
 }
 
+check_required_apps() {
+    apps=("jq" "curl")
+
+    for app in "${apps[@]}"; do
+        if ! command -v "$app" &>/dev/null; then
+            echo "The application '$app' is not installed."
+            exit 1
+        fi
+    done
+
+    echo "All required applications are installed."
+}
+
 # Create the script usage menu
 usage() {
   cat <<EOF | sed -e 's/^  //'
@@ -221,6 +234,8 @@ case "${ACTION}" in
 
 "start")
   passphrase_reset
+
+  check_required_apps
 
   get_host_ip
 


### PR DESCRIPTION
Summary: Added a check for required applications (jq,  curl) to the start command flow.

Details: I encountered an issue where running the start command without having jq installed caused all containers to appear as if they were running correctly. However, when using Fleet, the agent was unable to receive messages. 

To prevent similar issues for other users, this PR introduces a validation step within the start command. The script now checks for the presence of all necessary applications before proceeding to start the containers. If any required application is missing, the script will notify the user with a clear message and exit, ensuring that all dependencies are met before execution continues.