### PR TITLE
Update Docker image pull logic for Elastic Agent based on STACK_VERSION

### DIFF
--- a/elastic-container.sh
+++ b/elastic-container.sh
@@ -229,7 +229,11 @@ case "${ACTION}" in
   # Collect the Elastic, Kibana, and Elastic-Agent Docker images
   docker pull "docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}"
   docker pull "docker.elastic.co/kibana/kibana:${STACK_VERSION}"
-  docker pull "docker.elastic.co/beats/elastic-agent:${STACK_VERSION}"
+  if [[ "${STACK_VERSION}" =~ ^9\..* ]]; then
+    docker pull "docker.elastic.co/elastic-agent/elastic-agent:${STACK_VERSION}"
+  else
+    docker pull "docker.elastic.co/beats/elastic-agent:${STACK_VERSION}"
+  fi
   ;;
 
 "start")


### PR DESCRIPTION
The command `./elastic-container.sh stage` try to pull the `elastic-agent` image from `docker.elastic.co/beats/elastic-agent` instead of `docker.elastic.co/elastic-agent/elastic-agent` ([changed since 9.0.0-rc1](https://www.elastic.co/guide/en/elastic-stack/9.0/release-notes-fleet-agent-9.0.0.html#breaking-changes-fleet-agent-9.0.0-rc1)).

I put a simple string comparison in the stage logic of `elastic-container.sh` to handle this change.