### PR TITLE
Add Env to Enable/Disable Installing Prebuilt Detection Rules

### DIFF
--- a/.env
+++ b/.env
@@ -18,6 +18,9 @@ STACK_VERSION=9.0.1
 # Testing pre-releases? Use the SNAPSHOT option below:
 # STACK_VERSION=8.11.0-SNAPSHOT
 
+# Enable installing Prebuilt Detection Rules
+PREBUILT_DETECTION_RULES=1
+
 # Bulk Enable Detection Rules by OS
 LinuxDR=0
 


### PR DESCRIPTION
I added the env variable `PREBUILT_DETECTION_RULES` to allow for disabling the install of the prebuilt detection rules to allow for a clean rule environment if desired. (Primarily this is to allow for importing custom rules to mimic production environments, I'll probably do another PR later to add this function natively to this project if thats cool with you)

Added the env and defaulted it to `1`. Also kept backwards compatibility be defaulting the variable to 1 if doesn't exist.

Moved subsequent Enable rule sections to only be run if the prebuilt rules are installed. 