### PR TITLE
Change elastic agent docker path

### DIFF
--- a/elastic-container.sh
+++ b/elastic-container.sh
@@ -229,7 +229,7 @@ case "${ACTION}" in
   # Collect the Elastic, Kibana, and Elastic-Agent Docker images
   docker pull "docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}"
   docker pull "docker.elastic.co/kibana/kibana:${STACK_VERSION}"
-  docker pull "docker.elastic.co/beats/elastic-agent:${STACK_VERSION}"
+  docker pull "docker.elastic.co/elastic-agent/elastic-agent:${STACK_VERSION}"
   ;;
 
 "start")


### PR DESCRIPTION
It seems that the elastic agent docker location changed.

The `./elastic-container.sh stage` command failed with :
```
9.0.1: Pulling from elasticsearch/elasticsearch
Digest: sha256:9244a573c48bc120c8ac4daf61d48dcda48db2b25fd1b3c4cbeb01aa175a8495
Status: Image is up to date for docker.elastic.co/elasticsearch/elasticsearch:9.0.1
docker.elastic.co/elasticsearch/elasticsearch:9.0.1
9.0.1: Pulling from kibana/kibana
Digest: sha256:8298fac9df65785fdd8f00f977d2484ecfed8d1c2172730d43ee33d092b45a3f
Status: Image is up to date for docker.elastic.co/kibana/kibana:9.0.1
docker.elastic.co/kibana/kibana:9.0.1
Error response from daemon: manifest for docker.elastic.co/beats/elastic-agent:9.0.1 not found: manifest unknown: manifest unknown
```