### PR TITLE
[FR] Restrict User Pass Info Echo to Verbose

### DIFF
--- a/elastic-container.sh
+++ b/elastic-container.sh
@@ -257,8 +257,10 @@ case "${ACTION}" in
   echo "READY SET GO!"
   echo
   echo "Browse to https://localhost:${KIBANA_PORT}"
-  echo "Username: ${ELASTIC_USERNAME}"
-  echo "Passphrase: ${ELASTIC_PASSWORD}"
+  if [ $verbose -eq 1 ]; then
+      echo "Username: ${ELASTIC_USERNAME}"
+      echo "Passphrase: ${ELASTIC_PASSWORD}"
+  fi
   echo
   ;;
 


### PR DESCRIPTION
## Summary

I would like to be able to use the elastic container project in CI/CD workflows e.g. in https://github.com/elastic/detection-rules/pull/4955. However, since the current default is to echo the user and password information, this makes it insecure for CI/CD as anyone would be able to read the log and access the stack during the workflow run. 

If we put this output behind verbose mode, we can use it in CI/CD without leaking credentials. 

Happy to make edits as you see fit @peasead.

Thanks! 