### PR TITLE
[FR] Add Stack Version Update Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ If you're interested in more details regarding this project and what to do once 
 1. `Git clone` this repo
 2. Install prerequisites (see below)
 3. Change into the `elastic-container/` folder
-4. Change the default password of `changeme` in the `.env` file (don't change the `elastic` username, it's a [required built-in user](https://www.elastic.co/guide/en/elasticsearch/reference/current/built-in-users.html))  
-5. Bulk enable pre-built detection rules by OS in the `.env` file (not required, see usage below)
-6. Make the `elastic-container.sh` shell script executable by running `chmod +x elastic-container.sh`
-7. Execute the `elastic-container.sh` shell script with the start argument `./elastic-container.sh start`
-8. Wait for the prompt to tell you to browse to https://localhost:5601 \
+4. **Set a current stack image tag** — pinned versions in `.env` can disappear from registries over time. Either run `bash ./elastic-container.sh update-version` (or `bash ./elastic-container.sh -u`) to set `STACK_VERSION` to the newest stable `x.y.z` tag listed for [elastic/elasticsearch on Docker Hub](https://hub.docker.com/r/elastic/elasticsearch/tags), or open that page and set `STACK_VERSION` in `.env` manually to a tag that exists for Elasticsearch, Kibana, and Elastic Agent. After `chmod +x`, you can use `./elastic-container.sh` instead of `bash ./elastic-container.sh`.
+5. Change the default password of `changeme` in the `.env` file (don't change the `elastic` username, it's a [required built-in user](https://www.elastic.co/guide/en/elasticsearch/reference/current/built-in-users.html))  
+6. Bulk enable pre-built detection rules by OS in the `.env` file (not required, see usage below)
+7. Make the `elastic-container.sh` shell script executable by running `chmod +x elastic-container.sh`
+8. Execute the `elastic-container.sh` shell script with the start argument `./elastic-container.sh start`
+9. Wait for the prompt to tell you to browse to https://localhost:5601 \
 (You may be presented a browser warning due to the self-signed certificates. You can type `thisisnotsafe` or click to proceed after which you will be directed to the Elastic log in screen)
 
 ## Requirements
@@ -92,6 +93,16 @@ WindowsDR=1
 
 MacOSDR=0
 ```
+
+### Updating `STACK_VERSION`
+
+If pulls fail because the tag in `.env` was removed or is outdated, refresh the pinned version before `stage` or `start`:
+
+```
+$ ./elastic-container.sh update-version
+```
+
+This queries the [elastic/elasticsearch](https://hub.docker.com/r/elastic/elasticsearch/tags) repository on Docker Hub, finds the highest stable tag matching `x.y.z` (SNAPSHOT and other non-semver tags are ignored), and rewrites the active `STACK_VERSION=` line in `.env`. The same behavior is available as a short flag: `./elastic-container.sh -u`. Docker does not need to be running for this action. For snapshot or pre-release builds, set `STACK_VERSION` in `.env` by hand to match a published tag.
 
 ### Starting
 

--- a/elastic-container.sh
+++ b/elastic-container.sh
@@ -46,19 +46,79 @@ check_required_apps() {
 # Create the script usage menu
 usage() {
   cat <<EOF | sed -e 's/^  //'
-  usage: ./elastic-container.sh [-v] (stage|start|stop|restart|status|help)
+  usage: ./elastic-container.sh [-v] [-u] (stage|start|stop|restart|status|update-version|help)
   actions:
-    stage     downloads all necessary images to local storage
-    start     creates a container network and starts containers
-    stop      stops running containers without removing them
-    destroy   stops and removes the containers, the network, and volumes created
-    restart   restarts all the stack containers
-    status    check the status of the stack containers
-    clear     clear all documents in logs and metrics indexes
-    help      print this message
+    stage           downloads all necessary images to local storage
+    start           creates a container network and starts containers
+    stop            stops running containers without removing them
+    destroy         stops and removes the containers, the network, and volumes created
+    restart         restarts all the stack containers
+    status          check the status of the stack containers
+    clear           clear all documents in logs and metrics indexes
+    update-version  set STACK_VERSION in .env to the newest stable x.y.z tag from Docker Hub (elastic/elasticsearch)
+    help            print this message
   flags:
-    -v        enable verbose output
+    -v              enable verbose output
+    -u              same as update-version (refreshes STACK_VERSION in .env), then exit
 EOF
+}
+
+# Set STACK_VERSION in .env to the highest stable semver tag listed for elastic/elasticsearch on Docker Hub.
+refresh_stack_version() {
+  check_required_apps
+
+  local hub_repo="https://hub.docker.com/v2/repositories/elastic/elasticsearch/tags"
+  local page=1
+  local curl_opts=(-fsSL)
+  if [ "${verbose:-0}" -eq 1 ]; then
+    curl_opts=(-fSL)
+  fi
+
+  local all_names=""
+  echo "Querying Docker Hub for elastic/elasticsearch tags..."
+  while [ "${page}" -le 40 ]; do
+    local json next
+    if ! json=$(curl "${curl_opts[@]}" "${hub_repo}?page_size=100&page=${page}"); then
+      echo "Failed to fetch Docker Hub tags (page ${page})." >&2
+      exit 1
+    fi
+    all_names+=$(jq -r '.results[].name' <<<"${json}")
+    all_names+=$'\n'
+    next=$(jq -r '.next // empty' <<<"${json}")
+    [ -z "${next}" ] && break
+    page=$((page + 1))
+  done
+
+  local latest
+  latest=$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' <<<"${all_names}" | sort -V | tail -1)
+  if [ -z "${latest}" ]; then
+    echo "Could not find a stable semver tag (x.y.z) on Docker Hub." >&2
+    exit 1
+  fi
+
+  local current
+  current=$(grep -E '^STACK_VERSION=' .env | head -1 | cut -d= -f2- | tr -d '\r')
+  if [ -z "${current}" ]; then
+    echo "No active STACK_VERSION= line found in .env." >&2
+    exit 1
+  fi
+
+  if [ "${current}" = "${latest}" ]; then
+    echo "STACK_VERSION is already ${latest} (newest stable tag found on Docker Hub)."
+    return 0
+  fi
+
+  case "$(uname -s)" in
+    Darwin)
+      sed -i '' "s/^STACK_VERSION=.*/STACK_VERSION=${latest}/" .env
+      ;;
+    *)
+      sed -i "s/^STACK_VERSION=.*/STACK_VERSION=${latest}/" .env
+      ;;
+  esac
+
+  echo "Updated STACK_VERSION in .env: ${current} -> ${latest}"
+  echo "Images pull from docker.elastic.co; tags match Docker Hub elastic/elasticsearch releases."
 }
 
 # Create a function to enable the Detection Engine and load prebuilt rules in Kibana
@@ -192,11 +252,15 @@ clear_documents() {
 OPTIND=1 # Reset in case getopts has been used previously in the shell.
 
 verbose=0
+update_stack_version_flag=0
 
-while getopts "v" opt; do
+while getopts "vu" opt; do
   case "$opt" in
   v)
     verbose=1
+    ;;
+  u)
+    update_stack_version_flag=1
     ;;
   *) ;;
   esac
@@ -206,21 +270,31 @@ shift $((OPTIND - 1))
 
 [ "${1:-}" = "--" ] && shift
 
-ACTION="${*:-help}"
-
 if [ $verbose -eq 1 ]; then
   exec 3<>/dev/stderr
 else
   exec 3<>/dev/null
 fi
 
+if [ "${update_stack_version_flag}" -eq 1 ]; then
+  refresh_stack_version
+  exit 0
+fi
+
+ACTION="${*:-help}"
+
 if docker compose >/dev/null; then
   COMPOSE="docker compose"
 elif command -v docker-compose >/dev/null; then
   COMPOSE="docker-compose"
 else
-  echo "elastic-container requires docker compose!"
-  exit 2
+  case "${ACTION}" in
+  help | "update-version") ;;
+  *)
+    echo "elastic-container requires docker compose!"
+    exit 2
+    ;;
+  esac
 fi
 
 case "${ACTION}" in
@@ -290,6 +364,10 @@ case "${ACTION}" in
 
 "clear")
   clear_documents
+  ;;
+
+"update-version")
+  refresh_stack_version
   ;;
 
 "help")


### PR DESCRIPTION
## Summary

Small addition to the `elastic-container.sh` script to provide tooling to update the `STACK_VERSION` variable in env to the latest `x.y.z` supported version of the Elastic stack. 

This can be useful in CI/CD pipelines where one may always want the latest available stack. 

Example Detection Rules workflow where we want to use this: https://github.com/elastic/detection-rules/blob/main/.github/workflows/esql-validation.yml#L43-L84

This will allow the workflow to always validate against the most recent ES|QL operators. 

## Example Run

![env_example_run](https://github.com/user-attachments/assets/4f860b64-9dc3-48ec-9c30-c77bcb824016)

